### PR TITLE
Fix typo (acceess -> access)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In `deploy/kubernetes.yaml` add in `env` section id which we got from `API` and 
 env:
   - name: LOAD_BALANCER_ID
   value: ""
-  - name: ACCEESS_TOKEN
+  - name: ACCESS_TOKEN
   value: ""
 ```
 

--- a/code/collector.py
+++ b/code/collector.py
@@ -12,9 +12,9 @@ except KeyError:
   sys.exit(1)
 
 try:
-  accessToken = os.environ['ACCEESS_TOKEN']
+  accessToken = os.environ['ACCESS_TOKEN']
 except KeyError:
-  print('Variable ACCEESS_TOKEN not defined')
+  print('Variable ACCESS_TOKEN not defined')
   sys.exit(1)
 
 
@@ -22,7 +22,7 @@ requestUrl = 'https://api.hetzner.cloud/v1/load_balancers/' + loadBalancerId
 
 def getLoadBalancerType(id):
     url = requestUrl
-    
+
     headers = {
         'Content-type': "application/json",
         'Authorization': "Bearer " +  accessToken
@@ -62,21 +62,21 @@ if __name__ == '__main__':
   except Exception as e:
     print('Couldnt get field', e )
     sys.exit(1)
-    
+
   for services in getLoadBalancerType(loadBalancerId)['load_balancer']['services']:
       if services['protocol'] == 'http':
           lbType = 'http'
       else:
           lbType = 'tcp'
 
-  
+
   HetznerLoadBalancerInfo = Info('hetzner_load_balancer', 'Hetzner Load Balancer Exporter build info', ['hetzner_load_balancer_id', 'hetzner_load_balancer_name'])
   HetznerOpenConnections = Gauge('hetzner_load_balancer_open_connections', 'Open Connections on Hetzner Load Balancer', ['hetzner_load_balancer_id', 'hetzner_load_balancer_name'])
   HetznerConnectionsPerSecond = Gauge('hetzner_load_balancer_connections_per_second', 'Connections per Second on Hetzner Load Balancer', ['hetzner_load_balancer_id', 'hetzner_load_balancer_name'])
   HetznerRequestsPerSecond = Gauge('hetzner_load_balancer_requests_per_second', 'Requests per Second on Hetzner Load Balancer', ['hetzner_load_balancer_id', 'hetzner_load_balancer_name'])
   HetznerBandwidthIn = Gauge('hetzner_load_balancer_bandwidth_in', 'Bandwidth in on Hetzner Load Balancer', ['hetzner_load_balancer_id', 'hetzner_load_balancer_name'])
   HetznerBandwidthOut = Gauge('hetzner_load_balancer_bandwidth_out', 'Bandwidth out on Hetzner Load Balancer', ['hetzner_load_balancer_id', 'hetzner_load_balancer_name'])
-  
+
   start_http_server(8000)
   print('Web server started on port 8000')
 
@@ -90,6 +90,6 @@ if __name__ == '__main__':
     if lbType == 'http':
       HetznerConnectionsPerSecond.labels(hetzner_load_balancer_id=loadBalancerId, hetzner_load_balancer_name=loadBalancerName).set_function(lambda: getMetrics('requests_per_second')["metrics"]["time_series"]["requests_per_second"]["values"][0][1])
     HetznerBandwidthIn.labels(hetzner_load_balancer_id=loadBalancerId, hetzner_load_balancer_name=loadBalancerName).set_function(lambda: getMetrics('bandwidth')["metrics"]["time_series"]["bandwidth.in"]["values"][0][1])
-    HetznerBandwidthOut.labels(hetzner_load_balancer_id=loadBalancerId, hetzner_load_balancer_name=loadBalancerName).set_function(lambda: getMetrics('bandwidth')["metrics"]["time_series"]["bandwidth.out"]["values"][0][1])     
-    
+    HetznerBandwidthOut.labels(hetzner_load_balancer_id=loadBalancerId, hetzner_load_balancer_name=loadBalancerName).set_function(lambda: getMetrics('bandwidth')["metrics"]["time_series"]["bandwidth.out"]["values"][0][1])
+
     time.sleep(1)

--- a/deploy/exporter/templates/deployment.yaml
+++ b/deploy/exporter/templates/deployment.yaml
@@ -35,8 +35,8 @@ spec:
           env:
           - name: LOAD_BALANCER_ID
             value: "{{ .Values.env.loadBalancerId }}"
-          - name: ACCEESS_TOKEN
-            value: "{{ .Values.env.acceessToken }}"
+          - name: ACCESS_TOKEN
+            value: "{{ .Values.env.accessToken }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/deploy/exporter/values.yaml
+++ b/deploy/exporter/values.yaml
@@ -31,7 +31,7 @@ podAnnotations:
 
 env:
   loadBalancerId: ""
-  acceessToken: ""
+  accessToken: ""
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/deploy/simple/kubernetes.yaml
+++ b/deploy/simple/kubernetes.yaml
@@ -24,7 +24,7 @@ spec:
         env:
         - name: LOAD_BALANCER_ID
           value: ""
-        - name: ACCEESS_TOKEN
+        - name: ACCESS_TOKEN
           value: ""
         resources:
           requests:


### PR DESCRIPTION
I noticed while deploying, that the variable `access_token` has been misspelled, so I've corrected it.

Please note this is a **breaking** change for the config, so anyone just pulling the latest image will end up with a broken config until they rename it too.

I see there are some whitespace changes that weren't visible in the diff before I pushed, but it looks like it's whitespace that shouldn't be there anyways? I tested it locally via Docker and it all works for me.