### PR TITLE
Optimise Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.8.6
+FROM python:3.8-slim
 
-ADD code /code
-RUN pip install -r /code/requirements.txt
+COPY code /code
+RUN pip install --no-cache-dir -r /code/requirements.txt
 
 WORKDIR /code
 ENV PYTHONPATH '/code/'


### PR DESCRIPTION
I've made a couple of changes to improve the container build (in my opinion at least).

Rationale for the changes made:

1. Switch from base Python image to `3.8-slim`. No changes to build time or functionality, but the container size on disk went down from 896MB to 134MB.
2. Change `ADD` to `COPY` [as preferred in the best practices.](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy)
3. Install without pip cache, because pip isn't run on the container again, and it adds a couple of MB to the size for no reason.