### PR TITLE
Implemented secret handling

### DIFF
--- a/code/exporter.py
+++ b/code/exporter.py
@@ -17,9 +17,9 @@ def load_env(var: str, default: Optional[any] = None) -> Optional[str]:
 
     if path_var not in os.environ:
         if default is None:
-            raise KeyError(f"Neither variable {var} nor {path_var} are defined")
+            raise KeyError(f"Neither variable '{var}' nor '{path_var}' are defined")
 
-        print(f"Variable {var} is not defined, using default {default}")
+        print(f"Variable '{var}' is not defined, using default '{default}'")
         return default
 
     path = Path(os.environ[path_var])
@@ -28,15 +28,19 @@ def load_env(var: str, default: Optional[any] = None) -> Optional[str]:
             return file.read().strip()
     except FileNotFoundError as error:
         if default is None:
-            raise KeyError(f"Missing secret file {path} specified for {path_var}") from error
+            raise KeyError(f"Missing secret file '{path}' specified for '{path_var}'") from error
 
-        print(f"Missing secret file for {path_var}, using default {default}")
+        print(f"Missing secret file for '{path_var}', using default '{default}'")
         return default
 
 
-load_balancer_ids = load_env('LOAD_BALANCER_IDS')
-access_token = load_env('ACCESS_TOKEN')
-SCRAPE_INTERVAL = load_env('SCRAPE_INTERVAL', 30)
+try:
+    load_balancer_ids = load_env('LOAD_BALANCER_IDS')
+    access_token = load_env('ACCESS_TOKEN')
+    SCRAPE_INTERVAL = load_env('SCRAPE_INTERVAL', 30)
+except KeyError as error:
+    print(str(error)[1:-1])
+    exit(1)
 
 HETZNER_CLOUD_API_URL_BASE = 'https://api.hetzner.cloud/v1'
 HETZNER_CLOUD_API_URL_LB = f'{HETZNER_CLOUD_API_URL_BASE}/load_balancers/'


### PR DESCRIPTION
As promised in #11, this PR adds support for secret files. 

Many container orchestrators provide a way to inject secret configuration values into application securely by mounting read-only files into their file system; the application is expected to read those files upon starting up.  
These changes modify configuration loading to:
 1. Try and read a configuration value from an environment variable `FOO`, if defined
 2. Try and read a file path from an environment variable `FOO_PATH`, if defined
 3. Try and read the file path from the variable, if it exists

If all three variants fail, and no default value is passed, a KeyError is raised. This should provide solid configuration handling and allow to specify all values as environment variables or secret files, with the environment always taking precedence - so existing installations are not affected.