### PR TITLE
Flexible input for envs in helm deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,15 @@ Deploy it to Kubernetes cluster
 kubectl apply -f deploy/kubernetes.yaml
 ```
 
-```yaml
-hetzner-exporter:
-  image: 
+Or use [helm](https://helm.sh/docs/) to deploy the exporter:  
+In `deploy/helm-chart/values.yaml` add in `env` section id which we got from `API` and `API TOKEN`
+
+```bash
+# Add repo
+helm repo add wacken89 https://wacken89.github.io/hetzner-load-balancer-prometheus-exporter
+helm repo update
+# Install chart
+helm install hcloud-lb-exporter wacken89/hetzner-load-balancer-exporter -f values.yml
 ```
 
 ### Check metrics page

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -33,14 +33,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
-          - name: LOAD_BALANCER_IDS
-            value: "{{ .Values.env.loadBalancerId }}"
-          - name: ACCESS_TOKEN
-            value: "{{ .Values.env.accessToken }}"
-          {{- if .Values.env.scrapeInterval }} 
-          - name: SCRAPE_INTERVAL
-            value: "{{ .Values.env.scrapeInterval }}"
-          {{- end }}
+            {{- toYaml .Values.env | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -30,9 +30,20 @@ podAnnotations:
 
 
 env:
-  loadBalancerId: ""
-  accessToken: ""
-  # scrapeInterval: 
+  # Set envs like in the kubernetes pod spec
+  - name: LOAD_BALANCER_IDS
+    value: "all"
+  - name: SCRAPE_INTERVAL
+    value: "60"
+  - name: ACCESS_TOKEN
+    value: ""
+  # Or set token via secret ref
+  # - name: ACCESS_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: token
+  #       name: hcloud
+
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
This adds the possibility to add any number of envs to the deployment when deployed via helm.

It also unifies the usage described in the [ReadMe](https://github.com/wacken89/hetzner-load-balancer-prometheus-exporter#kubernetes-usage) with the input needed for helm `values.yml`

