### PR TITLE
Feat: Add arm64 docker image support - closes #15

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,19 +12,25 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1
+
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: wacken/hetzner-load-balancer-prometheus-exporter
-          
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
@@ -32,3 +38,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This PR adds arm64  support for the docker image.

Since your implementation is pure python (no compiled and linked c libs) this would only require adding the plattform prob in the GitHub Action CI file and setting up QEMU.

I tested the arm64 build and it works like a charm:
![image](https://github.com/wacken89/hetzner-load-balancer-prometheus-exporter/assets/40325561/bba3e3cb-cfaf-4fe7-9ee1-b902ba62498e)

If you want to test it yourself you can use your own build or use [my image on Dockerhub](https://hub.docker.com/r/hegerdes/hetzner-load-balancer-prometheus-exporter) (i will delete it if you choose to merge this)

Fixes #15