### PR TITLE
Add health status metrics for label selector types

### DIFF
--- a/code/exporter.py
+++ b/code/exporter.py
@@ -203,7 +203,15 @@ if __name__ == '__main__':
                                 hetzner_load_balancer_name=lb_name).set(get_metrics('bandwidth',load_balancer_id)["metrics"]["time_series"]["bandwidth.out"]["values"][0][1])
 
             lb_info = get_load_balancer_info(load_balancer_id)['load_balancer']
-            for target in [x for x in lb_info['targets'] if x['type'] == 'server']:
+
+            targets = []
+            for x in lb_info['targets']:
+                if x['type'] == 'server':
+                    targets.append(x)
+                elif x['type'] == 'label_selector':
+                    targets.extend(x['targets'])
+
+            for target in targets:
                 for health_status in target['health_status']:
                     hetzner_service_state.labels(hetzner_load_balancer_id=load_balancer_id,
                                                  hetzner_load_balancer_name=lb_name,


### PR DESCRIPTION
This PR adds support for getting health metrics for load balancers with “label” targets.

Right now, the exporter only collects metrics for targets of type `server`.

Example API response with label target type:
```json
{
  "load_balancer": {
   "targets": [
      {
        "type": "label_selector",
        "use_private_ip": true,
        "label_selector": {
          "selector": "role=web"
        },
        "targets": [
          {
            "type": "server",
            "server": {
              "id": 12347
            },
            "health_status": [
              {
                "listen_port": 443,
                "status": "healthy"
              }
            ],
            "use_private_ip": true
          },
          {
            "type": "server",
            "server": {
              "id": 12348
            },
            "health_status": [
              {
                "listen_port": 443,
                "status": "healthy"
              }
            ],
            "use_private_ip": true
          }
        ]
      }
    ], 
  }
}
```