### PR TITLE
feat(chart): add servicemonitor and dashboard

### DIFF
--- a/deploy/helm-chart/src/dashboards/dashboard.json
+++ b/deploy/helm-chart/src/dashboards/dashboard.json
@@ -1,0 +1,1 @@
+../../../../example/grafana-dashboard/hetzner-load-balancer.json

--- a/deploy/helm-chart/templates/clusterrolebinding.yaml
+++ b/deploy/helm-chart/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.rbac.enabled (not (eq .Values.rbac.name "")) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ .Values.rbac.type }}Binding
+metadata:
+  labels:
+    {{- include "exporter.labels" . | nindent 4 }}
+  name: {{ include "exporter.fullname" . }}
+  {{- if eq .Values.rbac.type "Role" }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ .Values.rbac.type }}
+  name: {{ .Values.rbac.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "exporter.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm-chart/templates/dashboard.yaml
+++ b/deploy/helm-chart/templates/dashboard.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "exporter.labels" . | nindent 4 }}
+    {{- toYaml .Values.dashboard.labels | nindent 4 }}
+  name: {{ include "exporter.fullname" . }}
+  namespace: {{ .Values.dashboard.namespace | default .Release.Namespace }}
+data:
+  dashboard.yaml: |-
+    {{ $.Files.Get "src/dashboards/dashboard.json" | fromJson | toJson }}
+{{- end }}

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
     {{- end }}
       labels:
         {{- include "exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm-chart/templates/servicemonitor.yaml
+++ b/deploy/helm-chart/templates/servicemonitor.yaml
@@ -19,7 +19,7 @@ spec:
     matchLabels: 
       {{- include "exporter.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: metrics
+    - port: http
       scheme: "http"
       {{- if .Values.serviceMonitor.interval }}
       interval: {{ .Values.serviceMonitor.interval }}

--- a/deploy/helm-chart/templates/servicemonitor.yaml
+++ b/deploy/helm-chart/templates/servicemonitor.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "exporter.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "exporter.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  selector:
+    matchLabels: 
+      {{- include "exporter.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      scheme: "http"
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ .Values.serviceMonitor.metricRelabelings }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings: {{ .Values.serviceMonitor.relabelings }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm-chart/templates/servicemonitor.yaml
+++ b/deploy/helm-chart/templates/servicemonitor.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
   {{- end }}
 spec:
-  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel | quote }}
   selector:
     matchLabels: 
       {{- include "exporter.selectorLabels" . | nindent 6 }}

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -28,6 +28,7 @@ podAnnotations:
   prometheus.io/port: '8000'
   prometheus.io/path: '/'
 
+podLabels: {}
 
 env:
   # Set envs like in the kubernetes pod spec

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -23,6 +23,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  enabled: false
+  type: ClusterRole # ClusterRole or Role
+  name: "" # example: system:auth-delegator
+
 podAnnotations:
   prometheus.io/scrape: 'true'
   prometheus.io/port: '8000'

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -84,3 +84,22 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+dashboard:
+  enabled: false
+  namespace: "" # will be set to .Release.Namespace if empty
+  labels:
+    grafana_dashboard: "1"
+
+serviceMonitor:
+  enabled: false
+  namespace: ""
+  annotations: {}
+  labels: {}
+  jobLabel: ""
+  honorLabels: false
+  interval: ""
+  scrapeTimeout: ""
+  metricRelabelings: []
+  relabelings: []
+  selector: {}


### PR DESCRIPTION
This PR allows to collect the metrics via `ServiceMonitor` instead of scrape annotations. Also the example dashboard can be deployed via helm-chart. Also podLabels can be specified. Last but not least this PR allows adding `RoleBinding` or `ClusterRoleBinding` to the `ServiceAccount` which could be used with e.g. Vault secret injection to add the `system:auth-delegator` role to the `ServiceAccount`.