### PR TITLE
Hetzner API metrics fetch now uses query parameters instead of JSON body

### DIFF
--- a/code/exporter.py
+++ b/code/exporter.py
@@ -110,9 +110,9 @@ def get_server_name_from_cache(server_id: str) -> str:
 
 
 def get_metrics(metrics_type, lbid):
-    utc_offset_sec = time.altzone if time.localtime().tm_isdst else time.timezone
-    utc_offset = datetime.timedelta(seconds=-utc_offset_sec)
-    hetzner_date = datetime.datetime.now().replace(tzinfo=datetime.timezone(offset=utc_offset)).isoformat()
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+    start = (now - datetime.timedelta(hours=1)).isoformat() + "Z"
+    end = now.isoformat() + "Z"
 
     url = f"{HETZNER_CLOUD_API_URL_LB}{lbid}/metrics"
 
@@ -121,15 +121,16 @@ def get_metrics(metrics_type, lbid):
         'Authorization': f"Bearer {access_token}"
     }
 
-    data = {
+    params = {
         "type": metrics_type,
-        "start": hetzner_date,
-        "end": hetzner_date,
+        "start": start,
+        "end": end,
         "step": 60
     }
 
-    get = requests.get(url, headers=headers, data=json.dumps(data))
+    get = requests.get(url, headers=headers, params=params)
     return get.json()
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix: Hetzner API metrics fetch now uses query parameters instead of JSON body

Hetzner's `/load_balancers/{id}/metrics` endpoint no longer accepts GET requests with a JSON body. This caused a KeyError due to the missing 'metrics' key in the response.
 > https://docs.hetzner.cloud/reference/cloud#load-balancers-get-metrics-for-a-loadbalancer

This commit:
- Replaces the JSON body (`data=...`) with query parameters (`params=...`)
- Adds a 1-hour UTC time window to the `start` and `end` parameters to ensure valid metrics data is returned

Result: Prometheus exporter works again across all environments using current Hetzner API behavior.

# Before/After
When run the dockerfile locally before this PR, this happens:
```
$ docker run --rm -p 8000:8000   -e ACCESS_TOKEN=xxx   -e LOAD_BALANCER_IDS=xxx   -e SCRAPE_INTERVAL=30   hetzner-exporter
Hetzner Load Balancer Exporter is starting ...
Getting Info from Hetzner ...

Found Load Balancer

        Name:   test-loadbalancer1
        Id:     2471367
        Type:   tcp

Scrape interval: 30 seconds

Building server name cache from Hetzner for labeling ...
Retrieved 12 server names from Hetzner ...


Hetzner Load Balancer Exporter started
Visit http://localhost:8000/ to view the metrics
Traceback (most recent call last):
  File "/code/exporter.py", line 194, in <module>
    hetzner_load_balancer_name=lb_name).set(get_metrics('open_connections',load_balancer_id)["metrics"]["time_series"]["open_connections"]["values"][0][1])
KeyError: 'metrics'
```

After this pr, this happens:
```
$ docker run --rm -p 8000:8000   -e ACCESS_TOKEN=xxx   -e LOAD_BALANCER_IDS=xxx   -e SCRAPE_INTERVAL=30   hetzner-exporter
Hetzner Load Balancer Exporter is starting ...
Getting Info from Hetzner ...

Found Load Balancer

        Name:   test-loadbalancer1
        Id:     2471367
        Type:   tcp

Scrape interval: 30 seconds

Building server name cache from Hetzner for labeling ...
Retrieved 12 server names from Hetzner ...


Hetzner Load Balancer Exporter started
Visit http://localhost:8000/ to view the metrics
```