### PR TITLE
Error: Not an RFC 3339 date

### DIFF
--- a/code/exporter.py
+++ b/code/exporter.py
@@ -111,8 +111,8 @@ def get_server_name_from_cache(server_id: str) -> str:
 
 def get_metrics(metrics_type, lbid):
     now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
-    start = (now - datetime.timedelta(hours=1)).isoformat() + "Z"
-    end = now.isoformat() + "Z"
+    start = (now - datetime.timedelta(hours=1)).isoformat()
+    end = now.isoformat()
 
     url = f"{HETZNER_CLOUD_API_URL_LB}{lbid}/metrics"
 

--- a/code/exporter.py
+++ b/code/exporter.py
@@ -129,7 +129,16 @@ def get_metrics(metrics_type, lbid):
     }
 
     get = requests.get(url, headers=headers, params=params)
-    return get.json()
+    try:
+        data = get.json()
+        if "metrics" not in data:
+            print(f"[WARN] No 'metrics' key in response for {metrics_type} on LB {lbid}")
+            print("[DEBUG] Raw response:", data)
+        return data
+    except Exception as e:
+        print(f"[ERROR] Failed to parse metrics response: {e}")
+        print("[DEBUG] Raw response text:", get.text)
+        return {}
 
 
 


### PR DESCRIPTION
After the PR
https://github.com/wacken89/hetzner-load-balancer-prometheus-exporter/pull/25
The error would still occur;
```
Hetzner Load Balancer Exporter started
Visit http://localhost:8000/ to view the metrics
Traceback (most recent call last):
  File "/code/exporter.py", line 195, in <module>
    hetzner_load_balancer_name=lb_name).set(get_metrics('open_connections',load_balancer_id)["metrics"]["time_series"]["open_connections"]["values"][0][1])
KeyError: 'metrics'
```

The following error would be returned in the get-request;
```
[DEBUG] Raw response: {'error': {'code': 'invalid_input', 'message': "invalid input in fields 'start', 'end'", 'details': {'fields': [{'name': 'start', 'messages': ['Not an RFC 3339 date.']}, {'name': 'end', 'messages': ['Not an RFC 3339 date.']}]}}}
```
I am not sure why it worked locally for me after the commits - I must had done something wrong.

After this PR:
```
$ docker build --no-cache -t hetzner-exporter . //Maybe i forgot to run --no-cache before
$ docker run --rm -p 8000:8000   -e ACCESS_TOKEN=xxx   -e LOAD_BALANCER_IDS=xxx   -e SCRAPE_INTERVAL=30   hetzner-exporter
Hetzner Load Balancer Exporter is starting ...
Getting Info from Hetzner ...

Found Load Balancer

        Name:   test-loadbalancer1
        Id:     xxx
        Type:   tcp

Scrape interval: 30 seconds

Building server name cache from Hetzner for labeling ...
Retrieved 12 server names from Hetzner ...


Hetzner Load Balancer Exporter started
Visit http://localhost:8000/ to view the metrics
```
Furthermore i have added ekstra logging, so it is easier to see the actual error-message from the hetzner-api (if any) - If this is not wanted, I can just remove the commit :-)
