### PR TITLE
Add health status metrics for dedicated servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY code /code
 RUN pip install --no-cache-dir -r /code/requirements.txt
 
 WORKDIR /code
-ENV PYTHONPATH '/code/'
+ENV PYTHONPATH='/code/'
 
 EXPOSE 8000
 

--- a/code/exporter.py
+++ b/code/exporter.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
 
             targets = []
             for x in lb_info['targets']:
-                if x['type'] == 'server':
+                if x['type'] == 'server' or x['type'] == 'ip':
                     targets.append(x)
                 elif x['type'] == 'label_selector':
                     targets.extend(x['targets'])
@@ -225,8 +225,8 @@ if __name__ == '__main__':
                 for health_status in target['health_status']:
                     hetzner_service_state.labels(hetzner_load_balancer_id=load_balancer_id,
                                                  hetzner_load_balancer_name=lb_name,
-                                                 hetzner_target_id=target['server']['id'],
-                                                 hetzner_target_name=get_server_name_from_cache(target['server']['id']),
+                                                 hetzner_target_id=(target['ip']['ip'] if target['type'] == 'ip' else target['server']['id']),
+                                                 hetzner_target_name=(target['ip']['ip'] if target['type'] == 'ip' else get_server_name_from_cache(target['server']['id'])),
                                                  hetzner_target_port=health_status['listen_port'])\
                         .set((1 if health_status['status'] == 'healthy' else 0))
         time.sleep(int(SCRAPE_INTERVAL))


### PR DESCRIPTION
Before this commit, health status was only collected for cloud servers,
that are identified by their server id. This commit adds support also
for dedicated servers, that are identified by their IP.

Example dedicated server target in API response:
```json
            "targets": [
                {
                    "ip": {
                        "ip": "10.0.1.1"
                    },
                    "health_status": [
                        {
                            "listen_port": 80,
                            "status": "healthy"
                        }
                    ],
                    "type": "ip"
                }
            ],
```

I have also included a second commit to use "ENV key=value" in Dockerfile instead of legacy "ENV key value" as explained in https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/.
