### PR TITLE
Robustness fixes + Python 3.12 + dead code removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
-FROM python:3.8-slim
-
+FROM python:3.12-slim
+ 
 RUN addgroup --gid 11000 app && \
-    adduser -uid 11001 --disabled-login -gid 11000 --home /code app
-
+    adduser --uid 11001 --disabled-login --gid 11000 --home /code app
+ 
 COPY code /code
+ 
 RUN pip install --no-cache-dir -r /code/requirements.txt
-
+ 
 WORKDIR /code
+ 
 ENV PYTHONPATH='/code/'
-
+ENV PYTHONUNBUFFERED=1
+ 
 EXPOSE 8000
-
+ 
 USER 11001
-
-CMD ["python" , "-u", "/code/exporter.py"]
+ 
+CMD ["python", "-u", "/code/exporter.py"]
+ 

--- a/code/exporter.py
+++ b/code/exporter.py
@@ -1,27 +1,25 @@
 import datetime
 import time
-import json
 import os
 import sys
-from typing import Optional
+from typing import Optional, Any
 from prometheus_client import start_http_server, Gauge, Info
 import requests
 from pathlib import Path
 
+EXPORTER_VERSION = '1.6.0'
+HTTP_TIMEOUT = 15  # seconds for every Hetzner API call
 
-def load_env(var: str, default: Optional[any] = None) -> Optional[str]:
+
+def load_env(var: str, default: Optional[Any] = None) -> Optional[str]:
     if var in os.environ:
         return os.environ[var]
-
     path_var = f"{var}_PATH"
-
     if path_var not in os.environ:
         if default is None:
             raise KeyError(f"Neither variable '{var}' nor '{path_var}' are defined")
-
         print(f"Variable '{var}' is not defined, using default '{default}'")
         return default
-
     path = Path(os.environ[path_var])
     try:
         with path.open("r", encoding="utf-8") as file:
@@ -29,7 +27,6 @@ def load_env(var: str, default: Optional[any] = None) -> Optional[str]:
     except FileNotFoundError as error:
         if default is None:
             raise KeyError(f"Missing secret file '{path}' specified for '{path_var}'") from error
-
         print(f"Missing secret file for '{path_var}', using default '{default}'")
         return default
 
@@ -40,116 +37,128 @@ try:
     SCRAPE_INTERVAL = load_env('SCRAPE_INTERVAL', 30)
 except KeyError as error:
     print(str(error)[1:-1])
-    exit(1)
+    sys.exit(1)
+
 
 HETZNER_CLOUD_API_URL_BASE = 'https://api.hetzner.cloud/v1'
 HETZNER_CLOUD_API_URL_LB = f'{HETZNER_CLOUD_API_URL_BASE}/load_balancers/'
 HETZNER_CLOUD_API_URL_SERVER = f'{HETZNER_CLOUD_API_URL_BASE}/servers/'
 
+_HEADERS = {
+    'Content-type': "application/json",
+    'Authorization': f"Bearer {access_token}",
+}
 
-def get_all_load_balancers_ids() -> dict:
-    url = f'{HETZNER_CLOUD_API_URL_LB}'
-    headers = {
-        'Content-type': "application/json",
-        'Authorization': f"Bearer {access_token}"
-    }
 
-    get = requests.get(url, headers=headers)
-    return get.json()['load_balancers']
+def _api_get(url: str, params: Optional[dict] = None) -> dict:
+    """Single place to do HTTP GET against the Hetzner API.
+
+    Raises for HTTP errors and always returns a dict (empty dict on JSON
+    decoding failure). Adding a timeout prevents the exporter from hanging
+    forever if the Hetzner API stalls.
+    """
+    try:
+        response = requests.get(url, headers=_HEADERS, params=params, timeout=HTTP_TIMEOUT)
+    except requests.RequestException as error:
+        print(f"[ERROR] HTTP request to {url} failed: {error}")
+        return {}
+    if response.status_code >= 400:
+        print(f"[ERROR] {response.status_code} from {url}: {response.text[:300]}")
+        return {}
+    try:
+        return response.json()
+    except ValueError as error:
+        print(f"[ERROR] Could not decode JSON from {url}: {error}")
+        return {}
+
+
+def get_all_load_balancers_ids() -> list:
+    data = _api_get(HETZNER_CLOUD_API_URL_LB)
+    return data.get('load_balancers', [])
 
 
 def get_load_balancer_info(lbid) -> dict:
-    url = f'{HETZNER_CLOUD_API_URL_LB}{lbid}'
-
-    headers = {
-        'Content-type': "application/json",
-        'Authorization': f"Bearer {access_token}"
-    }
-
-    get = requests.get(url, headers=headers)
-    return get.json()
+    return _api_get(f'{HETZNER_CLOUD_API_URL_LB}{lbid}')
 
 
 def get_all_server_names() -> dict:
-    url = f'{HETZNER_CLOUD_API_URL_SERVER}'
+    """Build a map of {server_id: server_name}.
 
-    headers = {
-        'Content-type': "application/json",
-        'Authorization': f"Bearer {access_token}"
-    }
-
-    get = requests.get(url, headers=headers)
-    return {x['id']: x['name'] for x in get.json()['servers']}
-
-
-def get_server_info(server_id) -> dict:
-    url = f'{HETZNER_CLOUD_API_URL_SERVER}{server_id}'
-
-    headers = {
-        'Content-type': "application/json",
-        'Authorization': f"Bearer {access_token}"
-    }
-
-    get = requests.get(url, headers=headers)
-    return get.json()
+    Closes #28: when the project has no servers, or the API returns an
+    unexpected payload, Hetzner sometimes omits the 'servers' key entirely.
+    We fall back to an empty mapping instead of crashing.
+    """
+    data = _api_get(HETZNER_CLOUD_API_URL_SERVER)
+    servers = data.get('servers')
+    if not servers:
+        print("[WARN] No 'servers' found in Hetzner response — "
+              "starting with empty server name cache")
+        return {}
+    return {x['id']: x['name'] for x in servers}
 
 
-def get_server_name_from_cache(server_id: str) -> str:
+# Closes #22: get_server_info() was unused. Removed.
+
+
+def get_server_name_from_cache(server_id) -> str:
     global server_name_cache
     if server_id in server_name_cache:
         return server_name_cache[server_id]
-    else:
-        # Refresh cache
-        server_name_cache = get_all_server_names()
-        # Check again
-        if server_id in server_name_cache:
-            return server_name_cache[server_id]
-        else:
-            # If still not found, return id as name
-            return server_id
+    # Refresh cache once before giving up
+    server_name_cache = get_all_server_names()
+    return server_name_cache.get(server_id, str(server_id))
 
 
-def get_metrics(metrics_type, lbid):
+def get_metrics(metrics_type: str, lbid) -> dict:
     now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
     start = (now - datetime.timedelta(hours=1)).isoformat()
     end = now.isoformat()
-
     url = f"{HETZNER_CLOUD_API_URL_LB}{lbid}/metrics"
-
-    headers = {
-        'Content-type': "application/json",
-        'Authorization': f"Bearer {access_token}"
-    }
-
     params = {
         "type": metrics_type,
         "start": start,
         "end": end,
-        "step": 60
+        "step": 60,
     }
+    data = _api_get(url, params=params)
+    if "metrics" not in data:
+        print(f"[WARN] No 'metrics' key in response for {metrics_type} on LB {lbid}")
+    return data
 
-    get = requests.get(url, headers=headers, params=params)
+
+def extract_latest_metric_value(payload: dict, series_name: str) -> Optional[float]:
+    """Pull the latest [timestamp, value] datapoint for a given series.
+
+    Closes #27: if the time series is missing or empty, return None instead
+    of raising IndexError / KeyError.
+    """
     try:
-        data = get.json()
-        if "metrics" not in data:
-            print(f"[WARN] No 'metrics' key in response for {metrics_type} on LB {lbid}")
-            print("[DEBUG] Raw response:", data)
-        return data
-    except Exception as e:
-        print(f"[ERROR] Failed to parse metrics response: {e}")
-        print("[DEBUG] Raw response text:", get.text)
-        return {}
+        values = payload["metrics"]["time_series"][series_name]["values"]
+    except (KeyError, TypeError):
+        return None
+    if not values:
+        return None
+    last = values[-1]  # use the latest, not the first, datapoint
+    if not last or len(last) < 2:
+        return None
+    try:
+        return float(last[1])
+    except (TypeError, ValueError):
+        return None
 
+
+def set_gauge(gauge: Gauge, labels: dict, value: Optional[float]) -> None:
+    """Set a gauge value, skipping when no data is available."""
+    if value is None:
+        return
+    gauge.labels(**labels).set(value)
 
 
 if __name__ == '__main__':
-
     print('Hetzner Load Balancer Exporter is starting ...')
 
     if load_balancer_ids.lower() == 'all':
-        load_balancer_ids_list = []
-        for key in get_all_load_balancers_ids():
-            load_balancer_ids_list.append(key['id'])
+        load_balancer_ids_list = [lb['id'] for lb in get_all_load_balancers_ids()]
     else:
         load_balancer_ids_list = list(load_balancer_ids.split(","))
 
@@ -157,31 +166,35 @@ if __name__ == '__main__':
     print(f"Found Load Balancer{'s' if len(load_balancer_ids_list) > 1 else ''}")
 
     load_balancer_full_list = []
-
     for load_balancer_id in load_balancer_ids_list:
         load_balancer = get_load_balancer_info(load_balancer_id).get('load_balancer')
+        if not load_balancer:
+            print(f"[ERROR] Could not retrieve info for LB '{load_balancer_id}'. Skipping.")
+            continue
         try:
             load_balancer_name = load_balancer['name']
-        except Exception as e:
-            print("Couldn't get field", e )
+        except KeyError as e:
+            print("Couldn't get field", e)
             sys.exit(1)
 
+        load_balancer_type = 'tcp'
+        for service in load_balancer.get('services', []):
+            if service.get('protocol') in ('http', 'https'):
+                load_balancer_type = 'http'
+                break
 
-        for services in load_balancer['services']:
-            if services['protocol'] in ['http', 'https']:
-                LOAD_BALANCER_TYPE = 'http'
-            else:
-                LOAD_BALANCER_TYPE = 'tcp'
+        load_balancer_full_list.append([load_balancer_id, load_balancer_name, load_balancer_type])
+        print(f'\n\tName:\t{load_balancer_name}\n\tId:\t{load_balancer_id}\n\tType:\t{load_balancer_type}')
 
-        load_balancer_full_list.append([load_balancer_id, load_balancer_name, LOAD_BALANCER_TYPE])
-
-        print(f'\n\tName:\t{load_balancer_name}\n\tId:\t{load_balancer_id}\n\tType:\t{LOAD_BALANCER_TYPE}')
+    if not load_balancer_full_list:
+        print("[FATAL] No load balancers could be loaded. Exiting.")
+        sys.exit(1)
 
     print(f'\nScrape interval: {SCRAPE_INTERVAL} seconds')
 
     print('\nBuilding server name cache from Hetzner for labeling ...')
     server_name_cache = get_all_server_names()
-    print(f'Retrieved {len(server_name_cache.keys())} server names from Hetzner ...\n')
+    print(f'Retrieved {len(server_name_cache)} server names from Hetzner ...\n')
 
     id_name_list = ['hetzner_load_balancer_id', 'hetzner_load_balancer_name']
     hetzner_load_balancer_info = Info('hetzner_load_balancer', 'Hetzner Load Balancer Exporter build info')
@@ -190,43 +203,83 @@ if __name__ == '__main__':
     hetzner_requests_per_second = Gauge('hetzner_load_balancer_requests_per_second', 'Requests per Second on Hetzner Load Balancer', id_name_list)
     hetzner_bandwidth_in = Gauge('hetzner_load_balancer_bandwidth_in', 'Bandwidth in on Hetzner Load Balancer', id_name_list)
     hetzner_bandwidth_out = Gauge('hetzner_load_balancer_bandwidth_out', 'Bandwidth out on Hetzner Load Balancer', id_name_list)
+
     id_name_service_list = id_name_list + ['hetzner_target_id', 'hetzner_target_name', 'hetzner_target_port']
-    hetzner_service_state = Gauge('hetzner_load_balancer_service_state', 'Health status of Load Balancer\'s services', id_name_service_list)
+    hetzner_service_state = Gauge('hetzner_load_balancer_service_state', "Health status of Load Balancer's services", id_name_service_list)
 
     start_http_server(8000)
     print('\nHetzner Load Balancer Exporter started')
     print('Visit http://localhost:8000/ to view the metrics')
-    hetzner_load_balancer_info.info({'version': '1.2.0', 'buildhost': 'drake0103@gmail.com'})
+
+    hetzner_load_balancer_info.info({'version': EXPORTER_VERSION, 'buildhost': 'wacken89'})
 
     while True:
         for load_balancer_id, lb_name, load_balancer_type in load_balancer_full_list:
-            hetzner_openconnections.labels(hetzner_load_balancer_id=load_balancer_id,
-                                hetzner_load_balancer_name=lb_name).set(get_metrics('open_connections',load_balancer_id)["metrics"]["time_series"]["open_connections"]["values"][0][1])
-            hetzner_connections_per_second.labels(hetzner_load_balancer_id=load_balancer_id,
-                            hetzner_load_balancer_name=lb_name).set(get_metrics('connections_per_second',load_balancer_id)["metrics"]["time_series"]["connections_per_second"]["values"][0][1])
+            base_labels = {
+                'hetzner_load_balancer_id': load_balancer_id,
+                'hetzner_load_balancer_name': lb_name,
+            }
+
+            # Open connections + connections-per-second
+            set_gauge(
+                hetzner_openconnections, base_labels,
+                extract_latest_metric_value(
+                    get_metrics('open_connections', load_balancer_id),
+                    'open_connections',
+                ),
+            )
+            set_gauge(
+                hetzner_connections_per_second, base_labels,
+                extract_latest_metric_value(
+                    get_metrics('connections_per_second', load_balancer_id),
+                    'connections_per_second',
+                ),
+            )
+
             if load_balancer_type == 'http':
-                hetzner_requests_per_second.labels(hetzner_load_balancer_id=load_balancer_id,
-                                hetzner_load_balancer_name=lb_name).set(get_metrics('requests_per_second',load_balancer_id)["metrics"]["time_series"]["requests_per_second"]["values"][0][1])
-            hetzner_bandwidth_in.labels(hetzner_load_balancer_id=load_balancer_id,
-                                hetzner_load_balancer_name=lb_name).set(get_metrics('bandwidth',load_balancer_id)["metrics"]["time_series"]["bandwidth.in"]["values"][0][1])
-            hetzner_bandwidth_out.labels(hetzner_load_balancer_id=load_balancer_id,
-                                hetzner_load_balancer_name=lb_name).set(get_metrics('bandwidth',load_balancer_id)["metrics"]["time_series"]["bandwidth.out"]["values"][0][1])
+                set_gauge(
+                    hetzner_requests_per_second, base_labels,
+                    extract_latest_metric_value(
+                        get_metrics('requests_per_second', load_balancer_id),
+                        'requests_per_second',
+                    ),
+                )
 
-            lb_info = get_load_balancer_info(load_balancer_id)['load_balancer']
+            # Optimization: bandwidth in & out come from the same response —
+            # fetch it once instead of twice per scrape cycle.
+            bandwidth_payload = get_metrics('bandwidth', load_balancer_id)
+            set_gauge(
+                hetzner_bandwidth_in, base_labels,
+                extract_latest_metric_value(bandwidth_payload, 'bandwidth.in'),
+            )
+            set_gauge(
+                hetzner_bandwidth_out, base_labels,
+                extract_latest_metric_value(bandwidth_payload, 'bandwidth.out'),
+            )
 
+            lb_info = get_load_balancer_info(load_balancer_id).get('load_balancer', {})
             targets = []
-            for x in lb_info['targets']:
-                if x['type'] == 'server' or x['type'] == 'ip':
+            for x in lb_info.get('targets', []):
+                if x.get('type') in ('server', 'ip'):
                     targets.append(x)
-                elif x['type'] == 'label_selector':
-                    targets.extend(x['targets'])
+                elif x.get('type') == 'label_selector':
+                    targets.extend(x.get('targets', []))
 
             for target in targets:
-                for health_status in target['health_status']:
-                    hetzner_service_state.labels(hetzner_load_balancer_id=load_balancer_id,
-                                                 hetzner_load_balancer_name=lb_name,
-                                                 hetzner_target_id=(target['ip']['ip'] if target['type'] == 'ip' else target['server']['id']),
-                                                 hetzner_target_name=(target['ip']['ip'] if target['type'] == 'ip' else get_server_name_from_cache(target['server']['id'])),
-                                                 hetzner_target_port=health_status['listen_port'])\
-                        .set((1 if health_status['status'] == 'healthy' else 0))
+                for health_status in target.get('health_status', []):
+                    if target['type'] == 'ip':
+                        target_id = target['ip']['ip']
+                        target_name = target['ip']['ip']
+                    else:
+                        target_id = target['server']['id']
+                        target_name = get_server_name_from_cache(target['server']['id'])
+
+                    hetzner_service_state.labels(
+                        hetzner_load_balancer_id=load_balancer_id,
+                        hetzner_load_balancer_name=lb_name,
+                        hetzner_target_id=target_id,
+                        hetzner_target_name=target_name,
+                        hetzner_target_port=health_status['listen_port'],
+                    ).set(1 if health_status.get('status') == 'healthy' else 0)
+
         time.sleep(int(SCRAPE_INTERVAL))

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,3 +1,4 @@
-prometheus-client==0.13.1
-datetime==4.3
-requests==2.24.0
+prometheus_client>=0.20.0,<1.0.0
+requests>=2.32.0,<3.0.0
+urllib3>=2.2.0,<3.0.0
+ 


### PR DESCRIPTION
- Guard against empty metric values (closes #27)
- Guard against missing 'servers' key (closes #28)
- Remove unused get_server_info() (closes #22)
- Bump base image to python:3.12-slim (closes #23)
- Add HTTP timeouts to all Hetzner API calls
- Deduplicate bandwidth.in/.out API calls
- Use latest (not first) metric datapoint
- Centralize version constant