### PR TITLE
feat: observability stack, metrics/rate-limit improvements, pretty startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Local environment file — may contain the Hetzner API token. Never commit it.
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ The exporter can be configured using environment variables. Instead of providing
 | Optional `SCRAPE_INTERVAL` | value in seconds, default value is `30 seconds` |
 | Optional `SCRAPE_INTERVAL_PATH` | Path to a file containing the scrape interval |
 
+#### Docker Compose usage (all-in-one: exporter + Prometheus + Grafana)
+
+A ready-to-run stack lives in `deploy/docker-compose`. It builds the exporter
+from source and starts Prometheus and Grafana with the datasource and dashboard
+already provisioned.
+
+```bash
+cd deploy/docker-compose
+cp .env.example .env      # then set HETZNER_ACCESS_TOKEN (and optionally LOAD_BALANCER_IDS)
+docker compose up -d --build
+```
+
+Then open:
+
+- Exporter metrics: <http://localhost:8000>
+- Prometheus: <http://localhost:9090>
+- Grafana: <http://localhost:3000> (default login `admin` / `admin`) — the
+  **Hetzner Load Balancer** dashboard is under the *Hetzner* folder.
+
 #### Kubernetes usage
 
 In `deploy/kubernetes.yaml` add in `env` section id which we got from `API` and `API TOKEN`

--- a/code/exporter.py
+++ b/code/exporter.py
@@ -1,14 +1,27 @@
 import datetime
+import logging
 import time
 import os
+import signal
 import sys
 from typing import Optional, Any
 from prometheus_client import start_http_server, Gauge, Info
 import requests
 from pathlib import Path
 
-EXPORTER_VERSION = '1.6.0'
+EXPORTER_VERSION = '1.7.0'
 HTTP_TIMEOUT = 15  # seconds for every Hetzner API call
+PER_PAGE = 50  # maximum page size allowed by the Hetzner API
+STEP_SECONDS = 60  # metrics resolution in seconds
+METRICS_WINDOW_STEPS = 3  # how many steps back to request (we only use the latest point)
+RATE_LIMIT_MAX_WAIT = 60  # cap for how long we back off on HTTP 429
+API_MAX_RETRIES = 3  # retries for a single request when rate limited
+
+logging.basicConfig(
+    level=os.environ.get('LOG_LEVEL', 'INFO').upper(),
+    format='%(asctime)s %(levelname)s %(message)s',
+)
+log = logging.getLogger('hetzner-lb-exporter')
 
 
 def load_env(var: str, default: Optional[Any] = None) -> Optional[str]:
@@ -18,7 +31,7 @@ def load_env(var: str, default: Optional[Any] = None) -> Optional[str]:
     if path_var not in os.environ:
         if default is None:
             raise KeyError(f"Neither variable '{var}' nor '{path_var}' are defined")
-        print(f"Variable '{var}' is not defined, using default '{default}'")
+        log.info("Variable '%s' is not defined, using default '%s'", var, default)
         return default
     path = Path(os.environ[path_var])
     try:
@@ -27,16 +40,16 @@ def load_env(var: str, default: Optional[Any] = None) -> Optional[str]:
     except FileNotFoundError as error:
         if default is None:
             raise KeyError(f"Missing secret file '{path}' specified for '{path_var}'") from error
-        print(f"Missing secret file for '{path_var}', using default '{default}'")
+        log.warning("Missing secret file for '%s', using default '%s'", path_var, default)
         return default
 
 
 try:
     load_balancer_ids = load_env('LOAD_BALANCER_IDS')
     access_token = load_env('ACCESS_TOKEN')
-    SCRAPE_INTERVAL = load_env('SCRAPE_INTERVAL', 30)
+    SCRAPE_INTERVAL = int(load_env('SCRAPE_INTERVAL', 30))
 except KeyError as error:
-    print(str(error)[1:-1])
+    log.error(str(error)[1:-1])
     sys.exit(1)
 
 
@@ -49,32 +62,84 @@ _HEADERS = {
     'Authorization': f"Bearer {access_token}",
 }
 
+# Set to False at the start of every scrape cycle so we refresh the server-name
+# cache at most once per cycle even if several targets miss the cache.
+_server_cache_refreshed = False
+_running = True
+
+
+def _rate_limit_wait(response: requests.Response) -> float:
+    """Seconds to wait after a 429, derived from Hetzner's rate-limit headers."""
+    retry_after = response.headers.get('Retry-After')
+    if retry_after:
+        try:
+            return min(max(float(retry_after), 1.0), RATE_LIMIT_MAX_WAIT)
+        except ValueError:
+            pass
+    reset = response.headers.get('RateLimit-Reset')
+    if reset:
+        try:
+            wait = float(reset) - time.time()
+            return min(max(wait, 1.0), RATE_LIMIT_MAX_WAIT)
+        except ValueError:
+            pass
+    return min(RATE_LIMIT_MAX_WAIT, 5.0)
+
 
 def _api_get(url: str, params: Optional[dict] = None) -> dict:
     """Single place to do HTTP GET against the Hetzner API.
 
-    Raises for HTTP errors and always returns a dict (empty dict on JSON
-    decoding failure). Adding a timeout prevents the exporter from hanging
-    forever if the Hetzner API stalls.
+    Handles transport errors, HTTP errors and rate limiting (HTTP 429 with a
+    bounded back-off using the RateLimit-Reset/Retry-After headers). Always
+    returns a dict (empty dict on any failure). The timeout prevents the
+    exporter from hanging forever if the Hetzner API stalls.
     """
-    try:
-        response = requests.get(url, headers=_HEADERS, params=params, timeout=HTTP_TIMEOUT)
-    except requests.RequestException as error:
-        print(f"[ERROR] HTTP request to {url} failed: {error}")
-        return {}
-    if response.status_code >= 400:
-        print(f"[ERROR] {response.status_code} from {url}: {response.text[:300]}")
-        return {}
-    try:
-        return response.json()
-    except ValueError as error:
-        print(f"[ERROR] Could not decode JSON from {url}: {error}")
-        return {}
+    for attempt in range(1, API_MAX_RETRIES + 1):
+        try:
+            response = requests.get(url, headers=_HEADERS, params=params, timeout=HTTP_TIMEOUT)
+        except requests.RequestException as error:
+            log.error("HTTP request to %s failed: %s", url, error)
+            return {}
+        if response.status_code == 429:
+            wait = _rate_limit_wait(response)
+            log.warning("Rate limited on %s (attempt %d/%d), waiting %.1fs",
+                        url, attempt, API_MAX_RETRIES, wait)
+            time.sleep(wait)
+            continue
+        if response.status_code >= 400:
+            log.error("%s from %s: %s", response.status_code, url, response.text[:300])
+            return {}
+        try:
+            return response.json()
+        except ValueError as error:
+            log.error("Could not decode JSON from %s: %s", url, error)
+            return {}
+    log.error("Giving up on %s after %d rate-limited attempts", url, API_MAX_RETRIES)
+    return {}
+
+
+def _api_get_all(url: str, key: str, params: Optional[dict] = None) -> list:
+    """GET a paginated collection, following meta.pagination.next_page.
+
+    The Hetzner API returns at most 25 entries per page by default (50 max), so
+    fetching only the first page silently drops resources once a project grows
+    past that. This walks every page and concatenates the results.
+    """
+    params = dict(params or {})
+    params["per_page"] = PER_PAGE
+    items: list = []
+    page: Optional[int] = 1
+    while page:
+        params["page"] = page
+        data = _api_get(url, params=params)
+        items.extend(data.get(key, []))
+        pagination = (data.get("meta") or {}).get("pagination") or {}
+        page = pagination.get("next_page")
+    return items
 
 
 def get_all_load_balancers_ids() -> list:
-    data = _api_get(HETZNER_CLOUD_API_URL_LB)
-    return data.get('load_balancers', [])
+    return _api_get_all(HETZNER_CLOUD_API_URL_LB, 'load_balancers')
 
 
 def get_load_balancer_info(lbid) -> dict:
@@ -82,47 +147,53 @@ def get_load_balancer_info(lbid) -> dict:
 
 
 def get_all_server_names() -> dict:
-    """Build a map of {server_id: server_name}.
+    """Build a map of {server_id: server_name}, following pagination.
 
     Closes #28: when the project has no servers, or the API returns an
     unexpected payload, Hetzner sometimes omits the 'servers' key entirely.
     We fall back to an empty mapping instead of crashing.
     """
-    data = _api_get(HETZNER_CLOUD_API_URL_SERVER)
-    servers = data.get('servers')
+    servers = _api_get_all(HETZNER_CLOUD_API_URL_SERVER, 'servers')
     if not servers:
-        print("[WARN] No 'servers' found in Hetzner response — "
-              "starting with empty server name cache")
+        log.warning("No 'servers' found in Hetzner response — "
+                    "starting with empty server name cache")
         return {}
     return {x['id']: x['name'] for x in servers}
 
 
-# Closes #22: get_server_info() was unused. Removed.
-
-
 def get_server_name_from_cache(server_id) -> str:
-    global server_name_cache
+    global server_name_cache, _server_cache_refreshed
     if server_id in server_name_cache:
         return server_name_cache[server_id]
-    # Refresh cache once before giving up
-    server_name_cache = get_all_server_names()
+    # Refresh the cache at most once per scrape cycle before giving up.
+    if not _server_cache_refreshed:
+        server_name_cache = get_all_server_names()
+        _server_cache_refreshed = True
     return server_name_cache.get(server_id, str(server_id))
 
 
-def get_metrics(metrics_type: str, lbid) -> dict:
+def get_metrics(metric_types: list, lbid) -> dict:
+    """Fetch one or more metric types for a load balancer in a single request.
+
+    The Hetzner metrics endpoint accepts 'type' as an array, so all series
+    (open_connections, bandwidth, ...) can be retrieved with one API call
+    instead of one call per type — meaningfully cheaper against the hourly
+    rate limit. Only the latest datapoint is used, so we ask for a short
+    window rather than a full hour.
+    """
     now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
-    start = (now - datetime.timedelta(hours=1)).isoformat()
+    start = (now - datetime.timedelta(seconds=STEP_SECONDS * METRICS_WINDOW_STEPS)).isoformat()
     end = now.isoformat()
     url = f"{HETZNER_CLOUD_API_URL_LB}{lbid}/metrics"
     params = {
-        "type": metrics_type,
+        "type": metric_types,  # requests serialises a list as repeated ?type=a&type=b
         "start": start,
         "end": end,
-        "step": 60,
+        "step": STEP_SECONDS,
     }
     data = _api_get(url, params=params)
     if "metrics" not in data:
-        print(f"[WARN] No 'metrics' key in response for {metrics_type} on LB {lbid}")
+        log.warning("No 'metrics' key in response for %s on LB %s", metric_types, lbid)
     return data
 
 
@@ -154,47 +225,108 @@ def set_gauge(gauge: Gauge, labels: dict, value: Optional[float]) -> None:
     gauge.labels(**labels).set(value)
 
 
+def _supports_color() -> bool:
+    """Enable ANSI colours only on a real terminal (and honour NO_COLOR)."""
+    return sys.stdout.isatty() and 'NO_COLOR' not in os.environ
+
+
+_C = {
+    'reset': '\033[0m', 'bold': '\033[1m', 'dim': '\033[2m',
+    'cyan': '\033[36m', 'green': '\033[32m', 'yellow': '\033[33m',
+    'blue': '\033[34m', 'magenta': '\033[35m',
+} if _supports_color() else {k: '' for k in (
+    'reset', 'bold', 'dim', 'cyan', 'green', 'yellow', 'blue', 'magenta')}
+
+
+def print_banner() -> None:
+    line = '═' * 60
+    print(f"{_C['cyan']}{line}{_C['reset']}")
+    print(f"{_C['cyan']}  {_C['bold']}Hetzner Load Balancer Exporter{_C['reset']}"
+          f"{_C['cyan']}  ·  v{EXPORTER_VERSION}{_C['reset']}")
+    print(f"{_C['cyan']}{line}{_C['reset']}", flush=True)
+
+
+def print_summary(load_balancers: list, server_count: int) -> None:
+    """Pretty per-load-balancer table plus a compact runtime summary."""
+    # load_balancers: list of (id, name, type, service_count)
+    id_w = max([len('ID')] + [len(str(lb[0])) for lb in load_balancers])
+    name_w = max([len('NAME')] + [len(str(lb[1])) for lb in load_balancers])
+    type_w = max(len('TYPE'), 4)
+
+    print(f"\n{_C['bold']}Discovered {len(load_balancers)} load balancer"
+          f"{'s' if len(load_balancers) != 1 else ''}:{_C['reset']}\n")
+    header = (f"  {_C['dim']}{'ID':<{id_w}}  {'NAME':<{name_w}}  "
+              f"{'TYPE':<{type_w}}  SERVICES{_C['reset']}")
+    print(header)
+    print(f"  {_C['dim']}{'─' * (id_w + name_w + type_w + 20)}{_C['reset']}")
+    for lb_id, name, lb_type, svc_count in load_balancers:
+        type_colour = _C['green'] if lb_type == 'http' else _C['blue']
+        print(f"  {lb_id!s:<{id_w}}  {_C['bold']}{name:<{name_w}}{_C['reset']}  "
+              f"{type_colour}{lb_type:<{type_w}}{_C['reset']}  {svc_count}")
+
+    print(f"\n  {_C['dim']}Server name cache :{_C['reset']} "
+          f"{_C['green']}{server_count}{_C['reset']} servers")
+    print(f"  {_C['dim']}Scrape interval   :{_C['reset']} {SCRAPE_INTERVAL}s")
+    print(f"  {_C['dim']}Metrics endpoint  :{_C['reset']} "
+          f"{_C['magenta']}http://localhost:8000/{_C['reset']}")
+    print(f"{_C['cyan']}{'═' * 60}{_C['reset']}\n", flush=True)
+
+
+def _handle_signal(signum, _frame) -> None:
+    global _running
+    log.info("Received signal %s, shutting down after current cycle ...", signum)
+    _running = False
+
+
+def _interruptible_sleep(seconds: int) -> None:
+    """Sleep in short slices so SIGTERM/SIGINT is honoured promptly."""
+    deadline = time.monotonic() + seconds
+    while _running and time.monotonic() < deadline:
+        time.sleep(min(1.0, deadline - time.monotonic()))
+
+
 if __name__ == '__main__':
-    print('Hetzner Load Balancer Exporter is starting ...')
+    print_banner()
+    log.info('Starting up, querying Hetzner Cloud API ...')
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
 
     if load_balancer_ids.lower() == 'all':
         load_balancer_ids_list = [lb['id'] for lb in get_all_load_balancers_ids()]
     else:
         load_balancer_ids_list = list(load_balancer_ids.split(","))
 
-    print('Getting Info from Hetzner ...\n')
-    print(f"Found Load Balancer{'s' if len(load_balancer_ids_list) > 1 else ''}")
-
     load_balancer_full_list = []
+    discovered = []  # richer rows (id, name, type, service_count) for the summary table
     for load_balancer_id in load_balancer_ids_list:
         load_balancer = get_load_balancer_info(load_balancer_id).get('load_balancer')
         if not load_balancer:
-            print(f"[ERROR] Could not retrieve info for LB '{load_balancer_id}'. Skipping.")
+            log.error("Could not retrieve info for LB '%s'. Skipping.", load_balancer_id)
             continue
         try:
             load_balancer_name = load_balancer['name']
         except KeyError as e:
-            print("Couldn't get field", e)
+            log.error("Couldn't get field %s", e)
             sys.exit(1)
 
+        services = load_balancer.get('services', [])
         load_balancer_type = 'tcp'
-        for service in load_balancer.get('services', []):
+        for service in services:
             if service.get('protocol') in ('http', 'https'):
                 load_balancer_type = 'http'
                 break
 
         load_balancer_full_list.append([load_balancer_id, load_balancer_name, load_balancer_type])
-        print(f'\n\tName:\t{load_balancer_name}\n\tId:\t{load_balancer_id}\n\tType:\t{load_balancer_type}')
+        discovered.append((load_balancer_id, load_balancer_name, load_balancer_type, len(services)))
 
     if not load_balancer_full_list:
-        print("[FATAL] No load balancers could be loaded. Exiting.")
+        log.error("No load balancers could be loaded. Exiting.")
         sys.exit(1)
 
-    print(f'\nScrape interval: {SCRAPE_INTERVAL} seconds')
-
-    print('\nBuilding server name cache from Hetzner for labeling ...')
     server_name_cache = get_all_server_names()
-    print(f'Retrieved {len(server_name_cache)} server names from Hetzner ...\n')
+
+    print_summary(discovered, len(server_name_cache))
 
     id_name_list = ['hetzner_load_balancer_id', 'hetzner_load_balancer_name']
     hetzner_load_balancer_info = Info('hetzner_load_balancer', 'Hetzner Load Balancer Exporter build info')
@@ -208,54 +340,39 @@ if __name__ == '__main__':
     hetzner_service_state = Gauge('hetzner_load_balancer_service_state', "Health status of Load Balancer's services", id_name_service_list)
 
     start_http_server(8000)
-    print('\nHetzner Load Balancer Exporter started')
-    print('Visit http://localhost:8000/ to view the metrics')
+    log.info('Hetzner Load Balancer Exporter started, metrics on http://localhost:8000/')
 
     hetzner_load_balancer_info.info({'version': EXPORTER_VERSION, 'buildhost': 'wacken89'})
 
-    while True:
+    while _running:
+        # Reset per-cycle state: drop stale target series (removed/renamed
+        # targets would otherwise linger forever) and allow one cache refresh.
+        _server_cache_refreshed = False
+        hetzner_service_state.clear()
+
         for load_balancer_id, lb_name, load_balancer_type in load_balancer_full_list:
             base_labels = {
                 'hetzner_load_balancer_id': load_balancer_id,
                 'hetzner_load_balancer_name': lb_name,
             }
 
-            # Open connections + connections-per-second
-            set_gauge(
-                hetzner_openconnections, base_labels,
-                extract_latest_metric_value(
-                    get_metrics('open_connections', load_balancer_id),
-                    'open_connections',
-                ),
-            )
-            set_gauge(
-                hetzner_connections_per_second, base_labels,
-                extract_latest_metric_value(
-                    get_metrics('connections_per_second', load_balancer_id),
-                    'connections_per_second',
-                ),
-            )
-
+            # Fetch every metric series in a single API call.
+            metric_types = ['open_connections', 'connections_per_second', 'bandwidth']
             if load_balancer_type == 'http':
-                set_gauge(
-                    hetzner_requests_per_second, base_labels,
-                    extract_latest_metric_value(
-                        get_metrics('requests_per_second', load_balancer_id),
-                        'requests_per_second',
-                    ),
-                )
+                metric_types.append('requests_per_second')
+            metrics_payload = get_metrics(metric_types, load_balancer_id)
 
-            # Optimization: bandwidth in & out come from the same response —
-            # fetch it once instead of twice per scrape cycle.
-            bandwidth_payload = get_metrics('bandwidth', load_balancer_id)
-            set_gauge(
-                hetzner_bandwidth_in, base_labels,
-                extract_latest_metric_value(bandwidth_payload, 'bandwidth.in'),
-            )
-            set_gauge(
-                hetzner_bandwidth_out, base_labels,
-                extract_latest_metric_value(bandwidth_payload, 'bandwidth.out'),
-            )
+            set_gauge(hetzner_openconnections, base_labels,
+                      extract_latest_metric_value(metrics_payload, 'open_connections'))
+            set_gauge(hetzner_connections_per_second, base_labels,
+                      extract_latest_metric_value(metrics_payload, 'connections_per_second'))
+            if load_balancer_type == 'http':
+                set_gauge(hetzner_requests_per_second, base_labels,
+                          extract_latest_metric_value(metrics_payload, 'requests_per_second'))
+            set_gauge(hetzner_bandwidth_in, base_labels,
+                      extract_latest_metric_value(metrics_payload, 'bandwidth.in'))
+            set_gauge(hetzner_bandwidth_out, base_labels,
+                      extract_latest_metric_value(metrics_payload, 'bandwidth.out'))
 
             lb_info = get_load_balancer_info(load_balancer_id).get('load_balancer', {})
             targets = []
@@ -282,4 +399,6 @@ if __name__ == '__main__':
                         hetzner_target_port=health_status['listen_port'],
                     ).set(1 if health_status.get('status') == 'healthy' else 0)
 
-        time.sleep(int(SCRAPE_INTERVAL))
+        _interruptible_sleep(SCRAPE_INTERVAL)
+
+    log.info('Hetzner Load Balancer Exporter stopped.')

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -1,0 +1,17 @@
+# Copy to .env and fill in your values: cp .env.example .env
+
+# Required: Hetzner Cloud API token (read permission is enough).
+HETZNER_ACCESS_TOKEN=
+
+# Optional: comma-separated load balancer IDs (e.g. 11,22,33) or "all".
+LOAD_BALANCER_IDS=all
+
+# Optional: seconds between scrapes of the Hetzner API.
+SCRAPE_INTERVAL=30
+
+# Optional: exporter log level (DEBUG, INFO, WARNING, ERROR).
+LOG_LEVEL=INFO
+
+# Optional: Grafana admin credentials (defaults: admin / admin).
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -1,11 +1,59 @@
-version: "3.9"
 services:
-  hetzner-load-balancer-prometheus-exporter:
-    image: test
-    container_name: hetzner-lb
+  exporter:
+    build:
+      # Build context is the repository root so the Dockerfile can COPY ./code.
+      context: ../..
+      dockerfile: Dockerfile
+    image: hetzner-load-balancer-prometheus-exporter:local
+    container_name: hetzner-lb-exporter
+    restart: unless-stopped
     ports:
-      - 8000
+      - "8000:8000"
     environment:
-      LOAD_BALANCER_IDS: 'all'
-      ACCESS_TOKEN: ''
-      SCRAPE_INTERVAL: '30'
+      LOAD_BALANCER_IDS: "${LOAD_BALANCER_IDS:-all}"
+      ACCESS_TOKEN: "${HETZNER_ACCESS_TOKEN:?set HETZNER_ACCESS_TOKEN in your environment or .env file}"
+      SCRAPE_INTERVAL: "${SCRAPE_INTERVAL:-30}"
+      LOG_LEVEL: "${LOG_LEVEL:-INFO}"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/').read()"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  prometheus:
+    image: prom/prometheus:v3.13.1
+    container_name: hetzner-lb-prometheus
+    restart: unless-stopped
+    depends_on:
+      - exporter
+    ports:
+      - "9090:9090"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=15d"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+
+  grafana:
+    image: grafana/grafana:13.1.0
+    container_name: hetzner-lb-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: "${GRAFANA_ADMIN_USER:-admin}"
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:-admin}"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      # The dashboard JSON is reused as-is from the repo's example directory.
+      - ../../example/grafana-dashboard:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/deploy/docker-compose/grafana/provisioning/dashboards/provider.yml
+++ b/deploy/docker-compose/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: Hetzner
+    orgId: 1
+    folder: Hetzner
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      # Dashboards mounted from the repo's example/grafana-dashboard directory.
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/docker-compose/grafana/provisioning/datasources/datasource.yml
+++ b/deploy/docker-compose/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: 30s

--- a/deploy/docker-compose/prometheus/prometheus.yml
+++ b/deploy/docker-compose/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: hetzner-load-balancer-exporter
+    static_configs:
+      # 'exporter' is the service name on the compose network; port 8000 is
+      # where the exporter serves Prometheus metrics.
+      - targets: ["exporter:8000"]

--- a/example/grafana-dashboard/hetzner-load-balancer.json
+++ b/example/grafana-dashboard/hetzner-load-balancer.json
@@ -1,405 +1,501 @@
 {
-    "__inputs": [],
-    "__requires": [
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
       {
-        "type": "grafana",
-        "id": "grafana",
-        "name": "Grafana",
-        "version": "7.1.1"
-      },
-      {
-        "type": "panel",
-        "id": "graph",
-        "name": "Graph",
-        "version": ""
-      },
-      {
-        "type": "datasource",
-        "id": "prometheus",
-        "name": "Prometheus",
-        "version": "1.0.0"
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-    ],
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": "-- Grafana --",
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
     },
-    "editable": true,
-    "gnetId": null,
-    "graphTooltip": 0,
-    "id": null,
-    "iteration": 1603287400201,
-    "links": [],
-    "panels": [
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "$datasource",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {}
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Latest number of open connections across the selected load balancers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5000 },
+              { "color": "red", "value": 10000 }
+            ]
           },
-          "overrides": []
+          "unit": "short"
         },
-        "fill": 1,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 9,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "hiddenSeries": false,
-        "id": 2,
-        "legend": {
-          "alignAsTable": true,
-          "avg": true,
-          "current": true,
-          "max": true,
-          "min": true,
-          "show": true,
-          "total": false,
-          "values": true
-        },
-        "lines": true,
-        "linewidth": 1,
-        "nullPointMode": "null",
-        "percentage": false,
-        "pluginVersion": "7.1.1",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "hetzner_load_balancer_open_connections{hetzner_load_balancer_name=\"$loadbalancer\"}",
-            "interval": "",
-            "legendFormat": "{{ hetzner_load_balancer_name }}",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Open Connections",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 1 },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(hetzner_load_balancer_open_connections{hetzner_load_balancer_name=~\"$loadbalancer\"})",
+          "legendFormat": "open connections",
+          "refId": "A"
         }
+      ],
+      "title": "Open Connections",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Latest connections-per-second rate across the selected load balancers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 1 },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(hetzner_load_balancer_connections_per_second{hetzner_load_balancer_name=~\"$loadbalancer\"})",
+          "legendFormat": "connections/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Connections / s",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Latest requests-per-second rate (HTTP/HTTPS load balancers only).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 1 },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(hetzner_load_balancer_requests_per_second{hetzner_load_balancer_name=~\"$loadbalancer\"})",
+          "legendFormat": "requests/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests / s",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Healthy targets vs. total targets across the selected load balancers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 1 },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(hetzner_load_balancer_service_state{hetzner_load_balancer_name=~\"$loadbalancer\"})",
+          "legendFormat": "healthy",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "count(hetzner_load_balancer_service_state{hetzner_load_balancer_name=~\"$loadbalancer\"})",
+          "legendFormat": "total",
+          "refId": "B"
+        }
+      ],
+      "title": "Healthy Targets",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "id": 101,
+      "panels": [],
+      "title": "Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 7 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["min", "max", "mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "hetzner_load_balancer_open_connections{hetzner_load_balancer_name=~\"$loadbalancer\"}",
+          "legendFormat": "{{hetzner_load_balancer_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Open Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 7 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["min", "max", "mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "hetzner_load_balancer_connections_per_second{hetzner_load_balancer_name=~\"$loadbalancer\"}",
+          "legendFormat": "{{hetzner_load_balancer_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Connections per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Only reported for HTTP/HTTPS load balancers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": ["min", "max", "mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "hetzner_load_balancer_requests_per_second{hetzner_load_balancer_name=~\"$loadbalancer\"}",
+          "legendFormat": "{{hetzner_load_balancer_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Bandwidth in (positive) and out (negative). Values are bytes per second as reported by the Hetzner metrics API.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisLabel": "- out / + in",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": "/.*out.*/" },
+            "properties": [
+              { "id": "custom.transform", "value": "negative-Y" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["min", "max", "mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "hetzner_load_balancer_bandwidth_in{hetzner_load_balancer_name=~\"$loadbalancer\"}",
+          "legendFormat": "{{hetzner_load_balancer_name}} in",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "hetzner_load_balancer_bandwidth_out{hetzner_load_balancer_name=~\"$loadbalancer\"}",
+          "legendFormat": "{{hetzner_load_balancer_name}} out",
+          "refId": "B"
+        }
+      ],
+      "title": "Bandwidth",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 102,
+      "panels": [],
+      "title": "Target Health",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Health status per target and listen port (1 = healthy, 0 = unhealthy).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": { "fillOpacity": 80, "lineWidth": 0 },
+          "mappings": [
+            { "options": { "0": { "color": "red", "index": 1, "text": "Unhealthy" } }, "type": "value" },
+            { "options": { "1": { "color": "green", "index": 0, "text": "Healthy" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 24 },
+      "id": 14,
+      "options": {
+        "alignValue": "left",
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "hetzner_load_balancer_service_state{hetzner_load_balancer_name=~\"$loadbalancer\"}",
+          "legendFormat": "{{hetzner_load_balancer_name}} / {{hetzner_target_name}}:{{hetzner_target_port}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Target Health",
+      "type": "state-timeline"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["hetzner", "load-balancer"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
       },
       {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "$datasource",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {}
-          },
-          "overrides": []
+        "allValue": ".*",
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(hetzner_load_balancer_open_connections, hetzner_load_balancer_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Load Balancer",
+        "multi": true,
+        "name": "loadbalancer",
+        "options": [],
+        "query": {
+          "query": "label_values(hetzner_load_balancer_open_connections, hetzner_load_balancer_name)",
+          "refId": "StandardVariableQuery"
         },
-        "fill": 1,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 8,
-          "w": 24,
-          "x": 0,
-          "y": 9
-        },
-        "hiddenSeries": false,
-        "id": 4,
-        "legend": {
-          "alignAsTable": true,
-          "avg": false,
-          "current": true,
-          "max": true,
-          "min": true,
-          "show": true,
-          "total": false,
-          "values": true
-        },
-        "lines": true,
-        "linewidth": 1,
-        "nullPointMode": "null",
-        "percentage": false,
-        "pluginVersion": "7.1.1",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "hetzner_load_balancer_connections_per_second{hetzner_load_balancer_name=\"$loadbalancer\"}",
-            "interval": "",
-            "legendFormat": "{{ hetzner_load_balancer_name }} cps",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Connections per Second",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "$datasource",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {}
-          },
-          "overrides": []
-        },
-        "fill": 1,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 8,
-          "w": 24,
-          "x": 0,
-          "y": 17
-        },
-        "hiddenSeries": false,
-        "id": 6,
-        "legend": {
-          "alignAsTable": true,
-          "avg": true,
-          "current": true,
-          "max": true,
-          "min": true,
-          "rightSide": false,
-          "show": true,
-          "total": false,
-          "values": true
-        },
-        "lines": true,
-        "linewidth": 1,
-        "nullPointMode": "null",
-        "percentage": false,
-        "pluginVersion": "7.1.1",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [
-          {
-            "alias": "/.*out.*/",
-            "transform": "negative-Y"
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "hetzner_load_balancer_bandwidth_in{hetzner_load_balancer_name=\"$loadbalancer\"}",
-            "interval": "",
-            "legendFormat": "{{ hetzner_load_balancer_name }}in",
-            "refId": "A"
-          },
-          {
-            "expr": "hetzner_load_balancer_bandwidth_out{hetzner_load_balancer_name=\"$loadbalancer\"}",
-            "instant": false,
-            "interval": "",
-            "legendFormat": "{{ hetzner_load_balancer_name }}out",
-            "refId": "B"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Bandwidth",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "bits",
-            "label": "- out / + in",
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
-    ],
-    "schemaVersion": 26,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": [
-        {
-          "current": {
-            "selected": true,
-            "text": "default",
-            "value": "default"
-          },
-          "hide": 0,
-          "includeAll": false,
-          "label": "Prometheus",
-          "multi": false,
-          "name": "datasource",
-          "options": [],
-          "query": "prometheus",
-          "queryValue": "",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "type": "datasource"
-        },
-        {
-          "allValue": null,
-          "current": {},
-          "datasource": "$datasource",
-          "definition": "label_values(hetzner_load_balancer_info,hetzner_load_balancer_name)",
-          "hide": 0,
-          "includeAll": false,
-          "label": "Load Balancer",
-          "multi": false,
-          "name": "loadbalancer",
-          "options": [],
-          "query": "label_values(hetzner_load_balancer_info,hetzner_load_balancer_name)",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
-        }
-      ]
-    },
-    "time": {
-      "from": "now-30m",
-      "to": "now"
-    },
-    "timepicker": {
-      "refresh_intervals": [
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ]
-    },
-    "timezone": "",
-    "title": "Hetzner Load Balancer",
-    "uid": "QW3gNNpGz",
-    "version": 1
-  }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {
+    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
+  },
+  "timezone": "",
+  "title": "Hetzner Load Balancer",
+  "uid": "QW3gNNpGz",
+  "version": 2
+}


### PR DESCRIPTION
## Exporter (code/exporter.py):
- Fix pagination: follow meta.pagination.next_page for load balancers and servers (default per_page is 25, so larger projects silently lost resources).
- Fetch all metric types in a single API call (type is an array) instead of one request per type — ~2.5x fewer calls against the hourly rate limit.
- Handle HTTP 429 with bounded back-off from RateLimit-Reset / Retry-After.
- Shorter metrics window (only the latest datapoint is used).
- Clear stale service_state series each cycle; refresh the server-name cache at most once per cycle.
- Switch print() to logging; add SIGTERM/SIGINT graceful shutdown.
- Add a coloured startup banner and a discovered-load-balancers table.

## Grafana dashboard:
- Fix the empty Load Balancer variable (queried the label-less Info metric).
- Modernise graph -> timeseries/stat/state-timeline (schemaVersion 39).
- New panels: Requests per Second, Target Health, overview stat row.
- Multi-select + Include All load balancer variable.

## Docker Compose:
- Full stack: build exporter from source + Prometheus + Grafana with the datasource and dashboard provisioned automatically.
- Token via HETZNER_ACCESS_TOKEN, add .env.example; gitignore .env.